### PR TITLE
Add dependencies required to enable parallel unit tests via paratest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,13 @@
         "farmos/farmos": "2.x-dev"
     },
     "require-dev": {
+        "brianium/paratest": "^4",
         "drupal/core-dev": "^9",
-        "zaporylie/composer-drupal-optimizations": "^1.1"
+        "zaporylie/composer-drupal-optimizations": "^1.1",
+        "phpspec/prophecy-phpunit": "^2.0"
+    },
+    "_comments": {
+        "phpspec/prophecy-phpunit": "Required until https://www.drupal.org/project/drupal/issues/3182653 is resolved"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Part of a larger change for https://www.drupal.org/project/farm/issues/3183682