### PR TITLE
Add dependencies required to enable parallel unit tests via paratest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,11 @@
         "farmos/farmos": "2.x-dev"
     },
     "require-dev": {
+        "brianium/paratest": "^4",
         "drupal/core-dev": "~9.1.0",
         "phpspec/prophecy-phpunit": "^2",
-        "zaporylie/composer-drupal-optimizations": "^1.1"
+        "zaporylie/composer-drupal-optimizations": "^1.1",
+        "nathandentzau/composer-patches-dev": "1.0.0"
     },
     "_comments": {
         "phpspec/prophecy-phpunit": "Required to fix ProphecyTrait not found, until Drupal core drops support for PHPUnit 8. See https://www.drupal.org/node/3176567"
@@ -59,6 +61,11 @@
             "web/modules/{$name}": ["type:drupal-module"],
             "web/themes/{$name}": ["type:drupal-theme"],
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
+        },
+        "patches-dev": {
+            "drupal/core": {
+                "Issue #3192365: Race Condition in 'public://simpletest' mkdir Call": "https://www.drupal.org/files/issues/2021-01-12/3192365-3.patch"
+            }
         }
     }
 }


### PR DESCRIPTION
Some background on the need for the patch can be found at https://github.com/farmOS/farmOS/pull/378