### PR TITLE
Use composer-merge-plugin to manage farmOS-map dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,14 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
         }
     ],
     "require": {
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "~9.1.0",
         "farmos/farmos": "2.x-dev",
-        "oomphinc/composer-installers-extender": "^2"
+        "oomphinc/composer-installers-extender": "^2",
+        "wikimedia/composer-merge-plugin": "^2.0"
     },
     "require-dev": {
         "brianium/paratest": "^4",
@@ -55,12 +52,10 @@
             }
         },
         "enable-patching": true,
-        "installer-types": ["npm-asset"],
         "installer-paths": {
             "web/core": ["type:drupal-core"],
             "web/profiles/farm": ["farmos/farmos"],
             "web/libraries/{$name}": ["type:drupal-library"],
-            "web/libraries/farmOS-map": ["npm-asset/farmos.org--farmos-map"],
             "web/modules/{$name}": ["type:drupal-module"],
             "web/themes/{$name}": ["type:drupal-theme"],
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
@@ -70,6 +65,11 @@
             "drupal/core": {
                 "Issue #3192365: Race Condition in 'public://simpletest' mkdir Call": "https://www.drupal.org/files/issues/2021-01-12/3192365-3.patch"
             }
+        },
+        "merge-plugin": {
+            "include": [
+                "web/profiles/farm/composer.libraries.json"
+            ]
         }
     }
 }


### PR DESCRIPTION
Use the `composer-merge-plugin` to manage the farmOS-map dependency. More info in: https://www.drupal.org/project/farm/issues/3230933

I tested by building a dev image via:
```
docker build \
  --build-arg PROJECT_REPO=https://github.com/paul121/composer-project.git \
  --build-arg PROJECT_VERSION=2.x-composer-merge-plugin \
  --build-arg FARMOS_REPO=https://github.com/paul121/farmOS.git \
  --build-arg FARMOS_VERSION=2.x-composer-merge-plugin \
  https://github.com/farmOS/farmOS.git#2.x:docker/dev \
  -t farmos/farmos:2.x-paul-dev \
```

Right now the map has some styling issues but that will be fixed with farmOS/farmOS-map#128 and a new release.