### PR TITLE
Add allow-plugins config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,14 @@
             "merge-extra": true,
             "merge-extra-deep": true
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
+            "wikimedia/composer-merge-plugin": true
+        }
     }
 }


### PR DESCRIPTION
Composer 2.2.0 has a new `allow-plugins` config option that we should define in our composer project: https://getcomposer.org/doc/06-config.md#allow-plugins

I noticed this warning when running `composer install` locally, you can also see it in the github action tests: https://github.com/paul121/farmOS/runs/4635317246?check_suite_focus=true#step:6:1034

> For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See https://getcomposer.org/allow-plugins
You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.

I've committed the config that is added to the `composer.json` after running `composer install` and allowing all the plugins that are prompted.