### PR TITLE
farmOS 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,6 @@
         "oomphinc/composer-installers-extender": "^2.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "_comments": {
         "drupal/entity_reference_validators": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255",
         "drupal/gin": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "farmos/farmos": "^2",
-        "drupal/entity_reference_validators": "@alpha",
+        "drupal/entity_reference_validators": "@beta",
         "drupal/gin": "@beta",
         "drupal/gin_toolbar": "@beta",
         "drupal/inline_entity_form": "@RC",

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,21 @@
     ],
     "require": {
         "farmos/farmos": "^2",
+        "drupal/entity_reference_validators": "^1.0@alpha",
+        "drupal/gin": "^3.0@beta",
+        "drupal/gin_toolbar": "^1.0@beta",
+        "drupal/inline_entity_form": "^1.0@RC",
         "oomphinc/composer-installers-extender": "^2.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "_comments": {
+        "drupal/entity_reference_validators": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255",
+        "drupal/gin": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255",
+        "drupal/gin_toolbar": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255",
+        "drupal/inline_entity_form": "Required here until a stable release is available. See https://www.drupal.org/project/farm/issues/3207255"
+    },
     "extra": {
         "installer-paths": {
             "web/core": ["type:drupal-core"],

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "farmos/farmos": "^2",
-        "drupal/entity_reference_validators": "^1.0@alpha",
-        "drupal/gin": "^3.0@beta",
-        "drupal/gin_toolbar": "^1.0@beta",
-        "drupal/inline_entity_form": "^1.0@RC",
+        "drupal/entity_reference_validators": "@alpha",
+        "drupal/gin": "@beta",
+        "drupal/gin_toolbar": "@beta",
+        "drupal/inline_entity_form": "@RC",
         "oomphinc/composer-installers-extender": "^2.0",
         "wikimedia/composer-merge-plugin": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
+        "farmos/farmos": "^2",
         "oomphinc/composer-installers-extender": "^2.0",
-        "farmos/farmos": "2.x-dev",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Opening this as a draft pull request ahead of the 2.0.0 "stable" release of farmOS.

This branch contains 1 commit that sets the `farmos/farmos` requirement to `^2` (from `2.x-dev`), and 2 commits related to https://www.drupal.org/project/farm/issues/3207255 (see this issue for more context).