### PR TITLE
Add config to allow plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,16 @@
             "merge-extra": true,
             "merge-extra-deep": true
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
+            "phpstan/extension-installer": true,
+            "wikimedia/composer-merge-plugin": true
+        }
     }
 }


### PR DESCRIPTION
This will simplify the build-farmOS.sh script.

Allowing to remove the following lines

https://github.com/farmOS/farmOS/blob/010a895092b30423b5b66ea06aa8f552ce8b4c18/docker/build-farmOS.sh#L41-L53

I'll add the related PR when it's ready